### PR TITLE
exclude files relating to paper from package build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,4 +70,7 @@ ignore = [
     "*.ipynb",
     "tests",
     "tests/*",
+    "*.png",
+    "*.bib",
+    "*.cff"
 ]


### PR DESCRIPTION
**What does your PR do?**

Should fix the error thrown by check-manifest when doing a release. It was expecting to find the .bib, .png and .cff files in the package. This tells sdist to explicity exclude them when building the package, we only need the code, readme and license in there
