### PR TITLE
Fix lambda functions to return float values

### DIFF
--- a/gliderad2cp/process_currents.py
+++ b/gliderad2cp/process_currents.py
@@ -116,8 +116,8 @@ def get_DAC(ADCP, gps_predive, gps_postdive):
     pre_t = gps_predive[:, 0].astype('datetime64[s]').astype(np.float64) # s
     post_t = gps_postdive[:, 0].astype('datetime64[s]').astype(np.float64) # s
 
-    lon2m = lambda x, y : gsw.distance([x-0.0005, x + 0.0005], [y, y])*1000
-    lat2m = lambda x, y : gsw.distance([x, x], [y-0.0005, y+0.0005])*1000
+    lon2m = lambda x, y: float(gsw.distance([x-0.0005, x+0.0005], [y, y])[0]) * 1000
+    lat2m = lambda x, y: float(gsw.distance([x, x], [y-0.0005, y+0.0005])[0]) * 1000
     
     ## Calculate displacements
     for idx in range(len(gps_predive)):


### PR DESCRIPTION
**What does your PR do?**

It changes the lambda functions within `process_currents.get_DAC`. Before the lambda functions returned 1-element arrays now they return a float.

**What issue does this PR address**

When using the toolbox with numpy version 2.4.3 `process_currents()` did not work. The error was `ValueError: setting an array element with a sequence.`. Newer numpy versions don't allow assigning a size-1 array into a scalar slot. The fix takes care of this. 

**Testing**

All PRs will be run against gliderad2cp's [automated tests](https://github.com/bastienqueste/gliderad2cp/blob/main/.github/workflows/tests.yml)

If the PR adds new functionality, add a test to cover it.
